### PR TITLE
update `grepl` SQL translation to match REGEXP_CONTAINS signature

### DIFF
--- a/R/dplyr.R
+++ b/R/dplyr.R
@@ -162,7 +162,9 @@ sql_translate_env.BigQueryConnection <- function(x) {
       Sys.time = sql_prefix("current_time"),
 
       # Regular expressions
-      grepl = sql_prefix("REGEXP_CONTAINS", 2),
+      grepl = function(pattern, x) {
+        dbplyr::build_sql("REGEXP_CONTAINS", list(x, pattern))
+      },
       gsub = function(match, replace, x) {
         dbplyr::build_sql("REGEXP_REPLACE", list(x, match, replace))
       },


### PR DESCRIPTION
`grepl` function in base R is incorrectly translated to `REGEXP_CONTAINS` by direct replacement. However, both reverse arguments order: 
 - `grepl(pattern, x)`
 - `REGEXP_CONTAINS(value, regexp)`

This PR fixes the order of arguments for `REGEXP_CONTAINS`.